### PR TITLE
Hobbyistic Hobby Endpoints & Postman Collection

### DIFF
--- a/server/Hobbyistic Endpoints.postman_collection.json
+++ b/server/Hobbyistic Endpoints.postman_collection.json
@@ -1,0 +1,325 @@
+{
+	"info": {
+		"_postman_id": "2451c031-7237-4839-aa61-cc8dceacb031",
+		"name": "Hobbyistic Endpoints",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+		"_exporter_id": "23759085"
+	},
+	"item": [
+		{
+			"name": "Login",
+			"request": {
+				"auth": {
+					"type": "bearer"
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"user\": {\n        \"email\": \"1234@gmail.com\",\n        \"password\": \"password\"\n    } \n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/api/login/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"api",
+						"login",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Register",
+			"request": {
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"name\": \"Pinto\",\n    \"email\": \"changewhendsendingnewpost@gmail.com\",\n    \"password\": \"password\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "localhost:3000/api/register",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"api",
+						"register"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Endpoint Authentication Test",
+			"protocolProfileBehavior": {
+				"disableBodyPruning": true
+			},
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjEzMmYyZjYyNTNmOTdmMTZmYzQxOCIsImV4cCI6MTY3MzEzODU0MiwiaWF0IjoxNjY3OTU0NTQyfQ.WbkUQEifDupXbiGhHFKK-MZv7eDxcjzPxCeFi-pdx38",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [
+					{
+						"key": "",
+						"value": "",
+						"type": "text",
+						"disabled": true
+					},
+					{
+						"key": "",
+						"value": "",
+						"type": "text",
+						"disabled": true
+					}
+				],
+				"body": {
+					"mode": "raw",
+					"raw": "{}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/api/testauth/",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"api",
+						"testauth",
+						""
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add Hobby",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{Bearer Token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"hobby\": {\n        \"name\": \"a simple test hobby\"\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/api/hobby",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"api",
+						"hobby"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Update Hobby",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{Bearer Token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PUT",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"hobby\": {\n        \"name\": \"erica is the best gf ever\"\n    }\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/api/hobby/636af8cd16c22d643afd36ef",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"api",
+						"hobby",
+						"636af8cd16c22d643afd36ef"
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get All Hobbies",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{Bearer Token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3000/api/hobby",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"api",
+						"hobby"
+					],
+					"query": [
+						{
+							"key": "",
+							"value": null,
+							"disabled": true
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Get Single Hobby",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{Bearer Token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "GET",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3000/api/hobby/636af8cd16c22d643afd36ef",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"api",
+						"hobby",
+						"636af8cd16c22d643afd36ef"
+					],
+					"query": [
+						{
+							"key": "",
+							"value": null,
+							"disabled": true
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delete Hobby",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{Bearer Token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3000/api/hobby/636af87b16c22d643afd36ec",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"api",
+						"hobby",
+						"636af87b16c22d643afd36ec"
+					],
+					"query": [
+						{
+							"key": "",
+							"value": null,
+							"disabled": true
+						}
+					]
+				}
+			},
+			"response": []
+		}
+	],
+	"variable": [
+		{
+			"key": "Bearer Token",
+			"value": "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpZCI6IjYzNjEzMmYyZjYyNTNmOTdmMTZmYzQxOCIsImV4cCI6MTY3MzEzODU0MiwiaWF0IjoxNjY3OTU0NTQyfQ.WbkUQEifDupXbiGhHFKK-MZv7eDxcjzPxCeFi-pdx38"
+		}
+	]
+}

--- a/server/controllers/hobby.controller.js
+++ b/server/controllers/hobby.controller.js
@@ -1,0 +1,88 @@
+const mongoose = require('mongoose');
+const User = mongoose.model('User');
+const Hobby = mongoose.model('Hobby');
+const passport = require('passport');
+const auth = require('../routes/auth');
+const { register } = require('./user.controller');
+
+module.exports.addHobby = (req, res, next) => {
+    if (req.auth == null) {
+        return res.sendStatus(401); 
+    }
+    User.findById(req.auth.id).then(function(user){
+        if (!user) { 
+            return res.sendStatus(401); 
+        }
+    });
+    let hobby = new Hobby();
+    hobby.name = req.body.hobby.name;
+    hobby.user = req.auth.id;
+    hobby.save((err, doc) => {
+        if (!err)
+            res.send(doc);
+        else {
+            return next(err);
+        }
+    })(req, res, next);
+}
+
+module.exports.getHobbies = (req, res, next) => {
+    if (req.auth == null) {
+        return res.sendStatus(401); 
+    }
+    User.findById(req.auth.id).then(function(user){
+        if (!user) { 
+            return res.sendStatus(401); 
+    }});
+    Hobby.find({ "user": { _id: req.auth.id}}).then(function(hobbies){
+        return res.send(hobbies)
+    });
+    (req, res, next);
+}
+
+module.exports.getSingleHobby = (req, res, next) => {
+    if (req.auth == null) {
+        return res.sendStatus(401); 
+    }
+    User.findById(req.auth.id).then(function(user){
+        if (!user) { 
+            return res.sendStatus(401); 
+    }});
+    Hobby.findOne({ "user": { _id: req.auth.id}, "_id": {_id: req.params.hobbyId}}).then(function(hobby){
+        return res.send(hobby)
+    });
+    (req, res, next);
+}
+
+module.exports.deleteHobby = (req, res, next) => {
+    if (req.auth == null) {
+        return res.sendStatus(401); 
+    }
+    User.findById(req.auth.id).then(function(user){
+        if (!user) { 
+            return res.sendStatus(401); 
+    }});
+    Hobby.deleteOne({ "user": { _id: req.auth.id}, "_id": {_id: req.params.hobbyId}}).then(function(hobby){
+        return res.sendStatus(200);
+    });
+    (req, res, next);
+}
+
+module.exports.updateHobby = (req, res, next) => {
+    if (req.auth == null) {
+        return res.sendStatus(401); 
+    }
+    User.findById(req.auth.id).then(function(user){
+        if (!user) { 
+            return res.sendStatus(401); 
+        }
+    });
+    Hobby.findOneAndUpdate({ "user": { _id: req.auth.id}, "_id": {_id: req.params.hobbyId}}, req.body.hobby, {returnDocument: 'after'}, (err, doc) => {
+        if (!err)
+            res.send(doc);
+        else {
+            return next(err);
+        }
+    })(req, res, next);
+}
+

--- a/server/models/db.js
+++ b/server/models/db.js
@@ -8,3 +8,4 @@ mongoose.connect(process.env.MONGODB_URI, (err) => {
 });
 
 require('./user.model');
+require('./hobby.model');

--- a/server/models/hobby.model.js
+++ b/server/models/hobby.model.js
@@ -1,0 +1,28 @@
+const mongoose = require('mongoose');
+
+var hobbySchema = new mongoose.Schema({
+    name: {
+        type: String,
+        required: 'Name field cannot be empty'
+    },
+    user: {
+        type: mongoose.Schema.Types.ObjectId,
+        ref: 'User',
+        required: 'Must be associated with a user '
+    },
+    extLinks: {
+        links: [{ type: String }],
+    }
+});
+
+hobbySchema.methods.toJSON = function(hobby){
+    return {
+        id: this._id,
+        name: this.name,
+        extLinks: this.extLinks
+        //favorited: user ? user.isFavorite(this._id) : false,
+        //author: this.author.toProfileJSONFor(user)
+    };
+};
+
+mongoose.model('Hobby', hobbySchema);

--- a/server/routes/index.router.js
+++ b/server/routes/index.router.js
@@ -2,9 +2,15 @@ const express = require('express');
 const router = express.Router();
 const auth = require('../routes/auth');
 const userController = require('../controllers/user.controller');
+const hobbyController = require('../controllers/hobby.controller');
 
 router.post('/register', userController.register);
 router.post('/login', userController.login);
 router.get('/testauth', auth.required, userController.testauth);
+router.post('/hobby', auth.required, hobbyController.addHobby);
+router.get('/hobby', auth.required, hobbyController.getHobbies);
+router.get('/hobby/:hobbyId', auth.required, hobbyController.getSingleHobby);
+router.delete('/hobby/:hobbyId', auth.required, hobbyController.deleteHobby);
+router.put('/hobby/:hobbyId', auth.required, hobbyController.updateHobby);
 
 module.exports = router;


### PR DESCRIPTION
# Hobbyistic Hobby Endpoints & Postman Collection

## Summary of Changes

* Added Hobby Model.
* Added CRUD routes for Hobby Model.
* Included Postman collection file to provide all API calls.

I've added the following routes to node JS:

```
router.post('/hobby', auth.required, hobbyController.addHobby);
router.get('/hobby', auth.required, hobbyController.getHobbies);
router.get('/hobby/:hobbyId', auth.required, hobbyController.getSingleHobby);
router.delete('/hobby/:hobbyId', auth.required, hobbyController.deleteHobby);
router.put('/hobby/:hobbyId', auth.required, hobbyController.updateHobby);
```
You can test them using the postman collection provided in the root of the server directory.

## Concerns

These are just very basic methods that work with minimal functionality. However, they can be improved iteratively. In addition, I need to work on better exception handling, like returning the correct error codes.