### PR TITLE
Calendar API Endpoints

### DIFF
--- a/Hobbyistic/src/app/routes.ts
+++ b/Hobbyistic/src/app/routes.ts
@@ -33,11 +33,11 @@ export const appRoutes: Routes = [
     children: [{ path: '', component: EditHobbyComponent}]
   },
   {
-    path: 'dashboard', component: UserComponent,
+    path: 'dashboard/:id', component: UserComponent,
     children: [{ path: '', component: DashboardComponent}]
   },
   {
-    path: 'external-links', component: ExternalLinksComponent,
+    path: 'external-links/:id', component: ExternalLinksComponent,
     children: [{ path: '', component: DashboardComponent}]
   },
   {

--- a/Hobbyistic/src/app/shared/widgets.model.ts
+++ b/Hobbyistic/src/app/shared/widgets.model.ts
@@ -5,12 +5,27 @@ export interface Widgets {
     taskWidget?:          TaskWidget;
     notesWidget?:         NotesWidget;
     externalLinksWidget?: ExternalLinksWidget;
+    calendarWidget?:      CalendarWidget;
     __v?:                 number;
 }
 
+export interface CalendarWidget {
+    events?: Event[];
+    _id?:    string;
+}
+
+export interface Event {
+    title?:       string;
+    description?: string;
+    startDate?:   Date;
+    endDate?:     Date;
+    frequency?:   string;
+    _id?:         string;
+}
+
 export interface ExternalLinksWidget {
-    _id?:   string;
     links?: Link[];
+    _id?:   string;
 }
 
 export interface Link {

--- a/Hobbyistic/src/app/shared/widgets.service.ts
+++ b/Hobbyistic/src/app/shared/widgets.service.ts
@@ -38,9 +38,9 @@ export class WidgetsService {
     return this.http.put<NotesWidget>("http://localhost:3000/api/hobby/" + hobby.id + "/widgets/notes/" + note._id, {note}, {headers: header});
   }
 
-  getExternalLinks(hobby: Hobby): Observable<ExternalLinksWidget[]> {
+  getExternalLinks(hobby: Hobby): Observable<Widgets> {
     let header = new HttpHeaders().set('Authorization',`Bearer ${localStorage.getItem('token')!}`);
-    return this.http.get<ExternalLinksWidget[]>("http://localhost:3000/api/hobby/" + hobby.id + "/widgets/externallinks", {headers: header});
+    return this.http.get<Widgets>("http://localhost:3000/api/hobby/" + hobby.id + "/widgets/externallinks", {headers: header});
   }
 
   getExternalLinksFromQuery(hobby: Hobby, query: String): Observable<ExternalLinksWidget[]> {

--- a/Hobbyistic/src/app/user/dashboard/dashboard.component.css
+++ b/Hobbyistic/src/app/user/dashboard/dashboard.component.css
@@ -67,6 +67,12 @@ h2
     border-radius: 2.5px;
 }
 
+.hobbyName h2
+{
+    padding-top: 1em;
+    color: black;
+}
+
 .boxLayout
 {
     text-align: center; 
@@ -96,11 +102,6 @@ a
 p
 {
     text-align: center;
-}
-
-.allWidgets
-{
-    margin-top: 5em;
 }
 
 .widgetBox

--- a/Hobbyistic/src/app/user/dashboard/dashboard.component.html
+++ b/Hobbyistic/src/app/user/dashboard/dashboard.component.html
@@ -20,9 +20,11 @@
             </div>
         </div>
     </div>
-    <!--<div class="row" *ngFor="let hobby of hobbies">
-        <h2>{{ hobby.name }}</h2>
-    </div>-->
+    <div class="row">
+        <div class="col-lg-12 hobbyName">
+            <h2 [ngModelOptions]="{standalone: true}" [(ngModel)]="hobby.name">{{ hobby.name }}</h2>
+        </div>
+    </div>
     <div class="row allWidgets">
         <div class="row">
             <div class="col-lg-6 widgetBox">
@@ -30,7 +32,7 @@
                     
                 </div>
                 <div class="col-lg-4">
-                    <p><a routerLink="/external-links">Useful Links</a></p>
+                    <p><a [routerLink]="['/external-links', hobby.id]">Useful Links</a></p>
                 </div>
                 <div class="col-lg-4">
                     

--- a/Hobbyistic/src/app/user/dashboard/dashboard.component.ts
+++ b/Hobbyistic/src/app/user/dashboard/dashboard.component.ts
@@ -3,6 +3,7 @@ import { Component, OnInit, Output } from '@angular/core';
 import { UntypedFormBuilder } from '@angular/forms';
 import { Hobby } from 'src/app/shared/hobby.model';
 import { UserService } from 'src/app/shared/user.service';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-dashboard',
@@ -12,13 +13,15 @@ import { UserService } from 'src/app/shared/user.service';
 })
 export class DashboardComponent implements OnInit {
 
-  constructor(public userService: UserService) { }
+  constructor(private route: ActivatedRoute, public userService: UserService) { }
 
-  hobbies: Hobby[] = [];
+  hobby: Hobby = {'name' : ''}
 
   ngOnInit(): void {
-    this.userService.GetAllHobbies().subscribe(hobbies => {
-      this.hobbies = hobbies;
+
+    this.hobby.id = this.route.snapshot.params['id'];
+    this.userService.GetSingleHobby(this.hobby).subscribe(resp => {
+      this.hobby = resp;
     });
   }
 

--- a/Hobbyistic/src/app/user/dashboard/external-links/external-links.component.html
+++ b/Hobbyistic/src/app/user/dashboard/external-links/external-links.component.html
@@ -21,7 +21,7 @@
         </div>
     </div>
     <div>
-        <div *ngFor = "let link of widgets">
+        <div *ngFor = "let link of widgets.externalLinksWidget?.links">
             <p>{{ link.title }}</p>
         </div>
     </div>

--- a/Hobbyistic/src/app/user/dashboard/external-links/external-links.component.html
+++ b/Hobbyistic/src/app/user/dashboard/external-links/external-links.component.html
@@ -20,5 +20,10 @@
             </div>
         </div>
     </div>
+    <div>
+        <div *ngFor = "let link of widgets">
+            <p>{{ link.title }}</p>
+        </div>
+    </div>
 </div>
 

--- a/Hobbyistic/src/app/user/dashboard/external-links/external-links.component.ts
+++ b/Hobbyistic/src/app/user/dashboard/external-links/external-links.component.ts
@@ -1,15 +1,39 @@
 import { Component, OnInit } from '@angular/core';
+import { UserService } from 'src/app/shared/user.service';
+import { WidgetsService } from 'src/app/shared/widgets.service';
+import { Link } from 'src/app/shared/widgets.model';
+import { Hobby } from 'src/app/shared/hobby.model';
+import { ActivatedRoute } from '@angular/router';
+import { ExternalLinksWidget } from 'src/app/shared/widgets.model';
+import { Widgets, TaskWidget, Task, NotesWidget } from 'src/app/shared/widgets.model';
 
 @Component({
   selector: 'app-external-links',
   templateUrl: './external-links.component.html',
-  styleUrls: ['./external-links.component.css']
+  styleUrls: ['./external-links.component.css'],
+  providers: [UserService]
 })
 export class ExternalLinksComponent implements OnInit {
 
-  constructor() { }
+  constructor(private route: ActivatedRoute, public WidgetService: WidgetsService, public UserService: UserService) { }
+
+  widgets: Widgets = { };
+  hobby: Hobby = {"name" : ""};
+  //hobbies: Hobby[] = []; 
 
   ngOnInit(): void {
+
+    this.hobby.id = this.route.snapshot.params['id'];
+    this.UserService.GetSingleHobby(this.hobby).subscribe(resp => {
+      this.hobby = resp;
+    });
+
+    this.WidgetService.getExternalLinks(this.hobby).subscribe(response => {
+      console.log(response);  
+      this.widgets = response;
+      console.log(this.widgets);
+        //this.links = this.externalLinksList.links[1];
+    });
   }
 
 }

--- a/Hobbyistic/src/app/user/main/main.component.html
+++ b/Hobbyistic/src/app/user/main/main.component.html
@@ -34,7 +34,7 @@
                 <div class="template">
                     <div class="row">
                         <div class="col-lg-8 centerAlign">
-                            <p><a routerLink="/dashboard">{{hobby.name}}</a></p>
+                            <p><a [routerLink]="['/dashboard', hobby.id]">{{hobby.name}}</a></p>
                         </div>
                         <div class="col-lg-4 centerAlign">
                             <img src="../assets/images/edit.png" alt="Edit" [routerLink]="['/edit-hobby', hobby.id]"/>

--- a/server/Hobbyistic Endpoints.postman_collection.json
+++ b/server/Hobbyistic Endpoints.postman_collection.json
@@ -199,7 +199,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:3000/api/hobby/63bf8886116a71a6f981791c",
+					"raw": "http://localhost:3000/api/hobby/63db3e07429276dccc217cf9",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -208,7 +208,7 @@
 					"path": [
 						"api",
 						"hobby",
-						"63bf8886116a71a6f981791c"
+						"63db3e07429276dccc217cf9"
 					],
 					"query": [
 						{
@@ -237,7 +237,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:3000/api/hobby/63caf8bddf1a4a7fcbf9b60e/widgets",
+					"raw": "http://localhost:3000/api/hobby/63db3e07429276dccc217cf9/widgets",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -246,7 +246,7 @@
 					"path": [
 						"api",
 						"hobby",
-						"63caf8bddf1a4a7fcbf9b60e",
+						"63db3e07429276dccc217cf9",
 						"widgets"
 					]
 				}
@@ -569,7 +569,7 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "http://localhost:3000/api/hobby/63c6ccc4b354191d93c00a5a/widgets/externallinks?query=What ",
+					"raw": "http://localhost:3000/api/hobby/63d85a75a61f9aa707542bc2/widgets/externallinks?query=How to fish",
 					"protocol": "http",
 					"host": [
 						"localhost"
@@ -578,14 +578,157 @@
 					"path": [
 						"api",
 						"hobby",
-						"63c6ccc4b354191d93c00a5a",
+						"63d85a75a61f9aa707542bc2",
 						"widgets",
 						"externallinks"
 					],
 					"query": [
 						{
 							"key": "query",
-							"value": "What "
+							"value": "How to fish"
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Add Calendar Event",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{Bearer Token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "POST",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"title\": \"ya it workeded\",\n    \"description\":  \"that was silly\",\n    \"startDate\": \"11/12/12\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/api/hobby/63db3e07429276dccc217cf9/widgets/calendar/events",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"api",
+						"hobby",
+						"63db3e07429276dccc217cf9",
+						"widgets",
+						"calendar",
+						"events"
+					],
+					"query": [
+						{
+							"key": "",
+							"value": null,
+							"disabled": true
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Update Calendar Event",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{Bearer Token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "PUT",
+				"header": [],
+				"body": {
+					"mode": "raw",
+					"raw": "{\n    \"title\": \"WORKING\"\n}",
+					"options": {
+						"raw": {
+							"language": "json"
+						}
+					}
+				},
+				"url": {
+					"raw": "http://localhost:3000/api/hobby/63db3e07429276dccc217cf9/widgets/calendar/events/63db44835ce1d0ebd30d7c78",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"api",
+						"hobby",
+						"63db3e07429276dccc217cf9",
+						"widgets",
+						"calendar",
+						"events",
+						"63db44835ce1d0ebd30d7c78"
+					],
+					"query": [
+						{
+							"key": "",
+							"value": null,
+							"disabled": true
+						}
+					]
+				}
+			},
+			"response": []
+		},
+		{
+			"name": "Delete Calendar Event",
+			"request": {
+				"auth": {
+					"type": "bearer",
+					"bearer": [
+						{
+							"key": "token",
+							"value": "{{Bearer Token}}",
+							"type": "string"
+						}
+					]
+				},
+				"method": "DELETE",
+				"header": [],
+				"url": {
+					"raw": "http://localhost:3000/api/hobby/63db3e07429276dccc217cf9/widgets/calendar/events/63db44985ce1d0ebd30d7c7e",
+					"protocol": "http",
+					"host": [
+						"localhost"
+					],
+					"port": "3000",
+					"path": [
+						"api",
+						"hobby",
+						"63db3e07429276dccc217cf9",
+						"widgets",
+						"calendar",
+						"events",
+						"63db44985ce1d0ebd30d7c7e"
+					],
+					"query": [
+						{
+							"key": "",
+							"value": null,
+							"disabled": true
 						}
 					]
 				}

--- a/server/controllers/hobby.controller.js
+++ b/server/controllers/hobby.controller.js
@@ -32,7 +32,10 @@ module.exports.addHobby = (req, res, next) => {
                         note: 'simple note'
                     },
                     externalLinksWidget: {
-
+                        links: []
+                    },
+                    calandarWidget: {
+                        events: []
                     }
                 });
                 newWidget.save((error, widget) => {

--- a/server/controllers/hobby.controller.js
+++ b/server/controllers/hobby.controller.js
@@ -34,7 +34,7 @@ module.exports.addHobby = (req, res, next) => {
                     externalLinksWidget: {
                         links: []
                     },
-                    calandarWidget: {
+                    calendarWidget: {
                         events: []
                     }
                 });

--- a/server/controllers/widgets.controller.js
+++ b/server/controllers/widgets.controller.js
@@ -184,9 +184,7 @@ module.exports.addEvent = (req, res, next) => {
         if (!user) { 
             return res.status(401).json({errors: {user: "Unauthorized"}}); 
         }
-        console.log('yeah it tried to get here')
         const newEvent = req.body;
-        console.log(req.body)
         Widgets.findOneAndUpdate(
             { user: req.auth.id, hobby: req.params.hobbyId }, 
             { $push: { 'calendarWidget.events': newEvent } }, 
@@ -198,6 +196,47 @@ module.exports.addEvent = (req, res, next) => {
                 if (!widget) {
                     return res.status(404).json({errors: {widget: "Widget not found"}});
                 }
+                res.send(widget.toJSON());
+            }
+        );
+    });
+}
+
+
+module.exports.updateEvent = (req, res, next) => {
+    if (req.auth == null) {
+        return res.status(401).json({errors: {user: "Unauthorized"}}); 
+    }
+    User.findById(req.auth.id).then(function(user){
+        if (!user) { 
+            return res.status(401).json({errors: {user: "Unauthorized"}}); 
+        }
+        //prevent body from being updated, this should be used for other methods in the future,
+        //issue is if user does not pass all attributes for body on update it will be overwritter, or maybe thats not a bad thing
+        //depending on how the user wants to interact without API.
+        //const updatedEvent = Object.assign({}, widget.calendarWidget.events.find(event => event._id.toString() === req.params.eventId), req.body);
+        /*
+        const updatedEvent = {};
+        Object.keys(req.body).forEach(key => {
+            updatedEvent[`calendarWidget.events.$.${key}`] = req.body[key];
+        });
+        */
+        updatedEvent = req.body;
+        console.log("was called");
+        console.log(req.body)
+        console.log(req.params.eventId)
+        Widgets.findOneAndUpdate(
+            { user: req.auth.id, hobby: req.params.hobbyId, "calendarWidget.events._id": req.params.eventId }, 
+            { $set: { 'calendarWidget.events.$': updatedEvent } }, 
+            { new: true },
+            (err, widget) => {
+                if (err) {
+                    return next(err);
+                }
+                if (!widget) {
+                    return res.status(404).json({errors: {widget: "Widget not found"}});
+                }
+                console.log(widget);
                 res.send(widget.toJSON());
             }
         );

--- a/server/controllers/widgets.controller.js
+++ b/server/controllers/widgets.controller.js
@@ -211,20 +211,20 @@ module.exports.updateEvent = (req, res, next) => {
         if (!user) { 
             return res.status(401).json({errors: {user: "Unauthorized"}}); 
         }
+        /*
         //prevent body from being updated, this should be used for other methods in the future,
         //issue is if user does not pass all attributes for body on update it will be overwritter, or maybe thats not a bad thing
         //depending on how the user wants to interact without API.
         //const updatedEvent = Object.assign({}, widget.calendarWidget.events.find(event => event._id.toString() === req.params.eventId), req.body);
-        /*
         const updatedEvent = {};
         Object.keys(req.body).forEach(key => {
             updatedEvent[`calendarWidget.events.$.${key}`] = req.body[key];
         });
-        */
         updatedEvent = req.body;
         console.log("was called");
         console.log(req.body)
         console.log(req.params.eventId)
+        */
         Widgets.findOneAndUpdate(
             { user: req.auth.id, hobby: req.params.hobbyId, "calendarWidget.events._id": req.params.eventId }, 
             { $set: { 'calendarWidget.events.$': updatedEvent } }, 
@@ -237,6 +237,31 @@ module.exports.updateEvent = (req, res, next) => {
                     return res.status(404).json({errors: {widget: "Widget not found"}});
                 }
                 console.log(widget);
+                res.send(widget.toJSON());
+            }
+        );
+    });
+}
+
+module.exports.deleteEvent = (req, res, next) => {
+    if (req.auth == null) {
+        return res.status(401).json({errors: {user: "Unauthorized"}}); 
+    }
+    User.findById(req.auth.id).then(function(user){
+        if (!user) { 
+            return res.status(401).json({errors: {user: "Unauthorized"}}); 
+        }
+        Widgets.findOneAndUpdate(
+            { user: req.auth.id, hobby: req.params.hobbyId }, 
+            { $pull: { 'calendarWidget.events': { _id: req.params.eventId }}}, 
+            { new: true },
+            (err, widget) => {
+                if (err) {
+                    return next(err);
+                }
+                if (!widget) {
+                    return res.status(404).json({errors: {widget: "Widget not found"}});
+                }
                 res.send(widget.toJSON());
             }
         );

--- a/server/controllers/widgets.controller.js
+++ b/server/controllers/widgets.controller.js
@@ -176,3 +176,31 @@ module.exports.getExternalLinksWithQuery = (req, res, next) => {
     });
 }
 
+module.exports.addEvent = (req, res, next) => {
+    if (req.auth == null) {
+        return res.status(401).json({errors: {user: "Unauthorized"}}); 
+    }
+    User.findById(req.auth.id).then(function(user){
+        if (!user) { 
+            return res.status(401).json({errors: {user: "Unauthorized"}}); 
+        }
+        console.log('yeah it tried to get here')
+        const newEvent = req.body;
+        console.log(req.body)
+        Widgets.findOneAndUpdate(
+            { user: req.auth.id, hobby: req.params.hobbyId }, 
+            { $push: { 'calendarWidget.events': newEvent } }, 
+            { new: true },
+            (err, widget) => {
+                if (err) {
+                    return next(err);
+                }
+                if (!widget) {
+                    return res.status(404).json({errors: {widget: "Widget not found"}});
+                }
+                res.send(widget.toJSON());
+            }
+        );
+    });
+}
+

--- a/server/models/widgets.model.js
+++ b/server/models/widgets.model.js
@@ -19,6 +19,15 @@ const notesWidgetSchema = new mongoose.Schema({
     note: {type: String, required: true}
 });
 
+const calendarWidgetSchema = new mongoose.Schema({
+    events: [{
+        title: {type: String, required: true},
+        description: {type: String},
+        startDate: {type: Date},
+        endDate: {type: Date}
+    }]
+ })
+
 const widgetsSchema = new mongoose.Schema({
     user: {
         type: mongoose.Schema.Types.ObjectId,
@@ -34,17 +43,8 @@ const widgetsSchema = new mongoose.Schema({
     taskWidget: taskWidgetSchema,
     notesWidget: notesWidgetSchema,
     externalLinksWidget: externalLinksWidgetSchema,
-    calendarWidgetWidget: calendarWidgetSchema
+    calendarWidget: calendarWidgetSchema
  });
-
- const calendarWidgetSchema = new mongoose.Schema({
-    events: [{
-        title: {type: String, required: true},
-        description: {type: String},
-        startDate: {type: Date},
-        endDate: {type: Date}
-    }]
- })
 
  const Widgets = mongoose.model('Widgets', widgetsSchema);
 
@@ -74,8 +74,8 @@ widgetsSchema.methods.toJSONForTasks = function() {
     };
 };
 
-//mongoose.model('TaskWidget', taskWidgetSchema);
-//mongoose.model('NotesWidget', notesWidgetSchema);
- mongoose.model('Widgets', widgetsSchema);
+mongoose.model('TaskWidget', taskWidgetSchema);
+mongoose.model('NotesWidget', notesWidgetSchema);
+mongoose.model('Widgets', widgetsSchema);
 
   

--- a/server/models/widgets.model.js
+++ b/server/models/widgets.model.js
@@ -24,7 +24,8 @@ const calendarWidgetSchema = new mongoose.Schema({
         title: {type: String, required: true},
         description: {type: String},
         startDate: {type: Date},
-        endDate: {type: Date}
+        endDate: {type: Date},
+        frequency: {type: String}
     }]
  })
 

--- a/server/models/widgets.model.js
+++ b/server/models/widgets.model.js
@@ -33,8 +33,18 @@ const widgetsSchema = new mongoose.Schema({
     },
     taskWidget: taskWidgetSchema,
     notesWidget: notesWidgetSchema,
-    externalLinksWidget: externalLinksWidgetSchema
+    externalLinksWidget: externalLinksWidgetSchema,
+    calendarWidgetWidget: calendarWidgetSchema
  });
+
+ const calendarWidgetSchema = new mongoose.Schema({
+    events: [{
+        title: {type: String, required: true},
+        description: {type: String},
+        startDate: {type: Date},
+        endDate: {type: Date}
+    }]
+ })
 
  const Widgets = mongoose.model('Widgets', widgetsSchema);
 
@@ -53,7 +63,8 @@ widgetsSchema.methods.toJSON = function() {
         hobby: this.hobby,
         taskWidget: this.taskWidget,
         notesWidget: this.notesWidget,
-        externalLinksWidget: this.externalLinksWidget
+        externalLinksWidget: this.externalLinksWidget,
+        calendarWidget: this.calendarWidget
     };
 };
 

--- a/server/routes/index.router.js
+++ b/server/routes/index.router.js
@@ -33,5 +33,6 @@ router.get('/hobby/:hobbyId/widgets/externallinks', auth.required, widgetsContro
 //calendar
 router.post('/hobby/:hobbyId/widgets/calendar/events', auth.required, widgetsController.addEvent);
 router.put('/hobby/:hobbyId/widgets/calendar/events/:eventId', auth.required, widgetsController.updateEvent);
+router.delete('/hobby/:hobbyId/widgets/calendar/events/:eventId', auth.required, widgetsController.deleteEvent);
 
 module.exports = router;

--- a/server/routes/index.router.js
+++ b/server/routes/index.router.js
@@ -30,5 +30,7 @@ router.put('/hobby/:hobbyId/widgets/notes', auth.required, widgetsController.upd
 //external links
 router.get('/hobby/:hobbyId/widgets/externallinks', auth.required, widgetsController.getExternalLinksWithQuery);
 
+//calendar
+router.post('/hobby/:hobbyId/widgets/calendar/events', auth.required, widgetsController.addEvent);
 
 module.exports = router;

--- a/server/routes/index.router.js
+++ b/server/routes/index.router.js
@@ -32,5 +32,6 @@ router.get('/hobby/:hobbyId/widgets/externallinks', auth.required, widgetsContro
 
 //calendar
 router.post('/hobby/:hobbyId/widgets/calendar/events', auth.required, widgetsController.addEvent);
+router.put('/hobby/:hobbyId/widgets/calendar/events/:eventId', auth.required, widgetsController.updateEvent);
 
 module.exports = router;


### PR DESCRIPTION
# Calendar API Endpoints

## Summary of changes

* Created calendar widgets Mongo model and added it as a subdocument of the widgets model.
* Created post endpoint for calendar events
* Created put endpoint for calendar events
* Created delete endpoint for calendar events
* Updated postman file to reflect new API endpoints
* Updated angular model to reflect new API attributes

## Questions & Concerns

* Most crud update endpoints will remove attributes of existing documents if they are not present in the request body. Do you know if this is the functionality we want?
* We still need to check user input on API calls other than using mongo constraints; this could be done using express-validator

## Important Changes for Developers

@MSG17 @sukhbirsekhon @Nicholas-Lawson 

Please ensure that you delete any existing hobby/widget schemas before testing the new endpoints, as new document schema attributes were added.
