### PR TITLE
Hobbyistic Assistant Widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ You will need to supply your own API Keys in a .env file to access external API 
 GOOGLE_CUSTOM_SEARCH_API_KEY='[YOUR_KEY_HERE]'
 GOOGLE_CUSTOM_SEARCH_ENGINE='[YOUR_KEY_HERE]
 JWT_AUTH_KEY='[YOUR_KEY_HERE]'
+OPENAI_KEY='[YOUR_KEY_HERE]'
 ```
 
 ### Running the API

--- a/server/controllers/hobby.controller.js
+++ b/server/controllers/hobby.controller.js
@@ -36,6 +36,13 @@ module.exports.addHobby = (req, res, next) => {
                     },
                     calendarWidget: {
                         events: []
+                    },
+                    assistantWidget: {
+                        messages: [{
+                            role: 'system',
+                            content: 'You are an assistant named Erica that helps users navigate a ' + hobby.name + ' hobby, be super nice and encouraging. PRETEND YOU ARE A HUMAN',
+                            date: new Date()
+                        }]
                     }
                 });
                 newWidget.save((error, widget) => {

--- a/server/controllers/widgets.controller.js
+++ b/server/controllers/widgets.controller.js
@@ -440,7 +440,7 @@ module.exports.getChatMessage = (req, res, next) => {
                       axios
                         .post("https://api.openai.com/v1/chat/completions", data, {
                           headers: {
-                            Authorization: `Bearer ${'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'}`,
+                            Authorization: `Bearer ${process.env.OPENAI_KEY}`,
                             "Content-Type": "application/json",
                           },
                         })

--- a/server/controllers/widgets.controller.js
+++ b/server/controllers/widgets.controller.js
@@ -6,6 +6,7 @@ const Post = mongoose.model('Posts');
 const widgetService = require('../services/widgets.service')
 const { GridFSBucket } = require('mongodb');
 const concat = require('concat-stream');
+const axios = require('axios');
 
 
 module.exports.getWigets = (req, res, next) => {
@@ -359,7 +360,7 @@ module.exports.getMotivationPosts = (req, res, next) => {
           });
       }
     });
-  };
+};
 
 module.exports.deleteMotivationPost = (req, res, next) => {
     const bucket = new GridFSBucket(mongoose.connection.db, {bucketName: 'photo'});
@@ -387,3 +388,103 @@ module.exports.deleteMotivationPost = (req, res, next) => {
         });
     });
 };
+
+
+module.exports.getChatMessage = (req, res, next) => {
+    const history = req.query.history;
+    const userMessage = req.query.message;
+    if (req.auth == null) {
+        return res.status(401).json({errors: {user: "Unauthorized"}}); 
+    }
+    User.findById(req.auth.id).then(function(user){
+        if (!user) { 
+            return res.status(401).json({errors: {user: "Unauthorized"}}); 
+        }
+        const newUserConvo = {
+            role: 'user',
+            content: userMessage,
+            date: new Date()
+        }
+        if (userMessage == null || userMessage == "") {
+            console.log('made here')
+            return Widgets.findOne({ user: req.auth.id, hobby: req.params.hobbyId }).select('assistantWidget').populate('assistantWidget.messages').then(function(assistantWidget) {
+                if (!assistantWidget) {
+                    return res.status(404).json({errors: {assistantWidget: "Not Found"}});
+                }
+                const messagesReturn = assistantWidget.assistantWidget.messages.map(message => ({ role: message.role, content: message.content, date: message.date}));
+                messagesReturn.splice(0, 1);
+                return res.json(messagesReturn);
+            })
+        }
+        Widgets.findOneAndUpdate(
+            { user: req.auth.id, hobby: req.params.hobbyId }, 
+            { $push: { 'assistantWidget.messages': newUserConvo } }, 
+            { new: true },
+            (err, widget) => {
+                if (err) {
+                    return next(err);
+                }
+                if (!widget) {
+                    return res.status(404).json({errors: {widget: "Widget not found"}});
+                }
+                Widgets.findOne({ user: req.auth.id, hobby: req.params.hobbyId }).select('assistantWidget').populate('assistantWidget.messages').then(function(assistantWidget) {
+                    if (!assistantWidget) {
+                        return res.status(404).json({errors: {assistantWidget: "Not Found"}});
+                    }
+                    const messagesReturn = assistantWidget.assistantWidget.messages.map(message => ({ role: message.role, content: message.content, date: message.date}));
+                    const messages = assistantWidget.assistantWidget.messages.map(message => ({ role: message.role, content: message.content }));
+                    const data = {
+                        model: "gpt-3.5-turbo",
+                        messages: messages
+                      };
+                      axios
+                        .post("https://api.openai.com/v1/chat/completions", data, {
+                          headers: {
+                            Authorization: `Bearer ${'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'}`,
+                            "Content-Type": "application/json",
+                          },
+                        })
+                        .then((response) => {
+                          const content = response.data.choices[0].message.content;
+                          aiUserConvo = {
+                            role: 'assistant',
+                            content: content,
+                            date: new Date()
+                          }
+                          Widgets.findOneAndUpdate(
+                            { user: req.auth.id, hobby: req.params.hobbyId }, 
+                            { $push: { 'assistantWidget.messages': aiUserConvo } }, 
+                            { new: true },
+                            (err, widget) => {
+                                if (err) {
+                                    return next(err);
+                                }
+                                if (!widget) {
+                                    return res.status(404).json({errors: {widget: "Widget not found"}});
+                                }
+                            }
+                        );
+                        if (history != null && history == 'true') {
+                        messagesReturn.push({
+                            role: 'assistant',
+                            content: content,
+                            date: new Date()
+                        })
+                        messagesReturn.splice(0, 1);
+                        return res.json(messagesReturn);
+                        }
+                        return res.json({ message: content });
+                        })
+                        .catch((error) => {
+                          console.error(error);
+                          next(error);
+                        });
+                }).catch(next);
+            }
+        );
+    });
+}
+
+
+
+

--- a/server/models/widgets.model.js
+++ b/server/models/widgets.model.js
@@ -19,6 +19,7 @@ const notesWidgetSchema = new mongoose.Schema({
     note: {type: String, required: true}
 });
 
+
 const calendarWidgetSchema = new mongoose.Schema({
     events: [{
         title: {type: String, required: true},
@@ -56,6 +57,13 @@ const motivationWidgetSchema = new mongoose.Schema({
     metadata: Object
   });
 
+const assistantWidgetSchema = new mongoose.Schema({
+    messages: [{
+        role: {type: String, required: true},
+        content: {type: String, required: true},
+        date: {type: Date, required: true}
+    }]
+})
 
 const widgetsSchema = new mongoose.Schema({
     user: {
@@ -73,6 +81,7 @@ const widgetsSchema = new mongoose.Schema({
     notesWidget: notesWidgetSchema,
     externalLinksWidget: externalLinksWidgetSchema,
     calendarWidget: calendarWidgetSchema,
+    assistantWidget: assistantWidgetSchema
     //motivationWidget: [{type: mongoose.Schema.Types.ObjectId, ref: 'Posts'}]
  });
 
@@ -102,6 +111,12 @@ widgetsSchema.methods.toJSON = function() {
 widgetsSchema.methods.toJSONForTasks = function() {
     return {
         taskWidget: this.taskWidget,
+    };
+};
+
+assistantWidgetSchema.methods.toJSONForAPI = function() {
+    return {
+        messages: this.messages.map(message => ({ role: message.role, content: message.content }))
     };
 };
 

--- a/server/routes/index.router.js
+++ b/server/routes/index.router.js
@@ -46,4 +46,7 @@ router.delete('/hobby/:hobbyId/widgets/motivation/post/:postId',  auth.required,
 router.get('/hobby/:hobbyId/widgets/motivation/post',  auth.required, widgetsController.getMotivationPosts);
 router.get('/hobby/:hobbyId/widgets/motivation/post/:postId/image',  auth.required, widgetsController.getPostImage);
 
+//assistant
+router.get('/hobby/:hobbyId/widgets/assistant',  auth.required, widgetsController.getChatMessage);
+
 module.exports = router;


### PR DESCRIPTION
# Hobbyistic Assistant Widget

## Summary of Changes 
I've created a Hobbyistic AI Assistant based on GPT3 NLP modeling that is trained to assist users in navigating their specified hobby and encourage them along the way.

* Created endpoint to access AI Assistant services and send message
* Created endpoint to access AI Assistant chat logs
* Created endpoint to access AI Assistant services and send messages while appending chat logs
* Updated postman documentation to be viewable on the web and have OK response examples for all endpoints. https://documenter.getpostman.com/view/23759085/2s93CHuF8e#d86749b2-17ea-4000-8b0b-c3be3e1e8a33

# Concerns

* If the hobby name changes from the user, the AI root document describing the assistant's functionality in relation to the user's respective hobby will not update.
* It will be necessary in the future to remove user/assistant conversations for the chat log array because the request payload could become too large for Open AI, though there is no documentation for this yet
* Add a limit for what a user can send to reduce token usage.

# Important Changes for Developers

If you would like to test our Hobbyistic AI Assistant, please ensure you register a key from OpenAI at https://platform.openai.com/account/api-keys and add the key to the server .env as OPENAI_KEY=[YOUR_KEY]

**Please ensure you clear your mongo hobby and widget collection as the schema has changed**

Also, your best place to view documentation is https://documenter.getpostman.com/view/23759085/2s93CHuF8e#d86749b2-17ea-4000-8b0b-c3be3e1e8a33